### PR TITLE
Change the access level for the function getColumns() & hasColumn()

### DIFF
--- a/src/UserStamping.php
+++ b/src/UserStamping.php
@@ -68,7 +68,7 @@ trait UserStamping {
      * Add DB table columns meta info
      *
      */
-    public function getColumns() {
+    protected function getColumns() {
         return \DB::connection()->getSchemaBuilder()->getColumnListing($this->getTable());
     }
 
@@ -76,7 +76,7 @@ trait UserStamping {
      * Add DB table columns meta info
      *
      */
-    public function hasColumn($name) {
+    protected function hasColumn($name) {
         return in_array($name, $this->getColumns());
     }
 


### PR DESCRIPTION
To avoid some conflicts it's better to keep `protected` access level here.
